### PR TITLE
[BUGFIX] Save and Exit opened TYPO3 BE in the module frame

### DIFF
--- a/Resources/Private/Templates/Permission/Edit.html
+++ b/Resources/Private/Templates/Permission/Edit.html
@@ -135,7 +135,7 @@
 		<f:form.hidden name="data[pages][{id}][perms_group]" value="{pageInfo.perms_group}" />
 		<f:form.hidden name="data[pages][{id}][perms_everybody]" value="{pageInfo.perms_everybody}" />
 		<f:form.hidden name="depth" value="{depth}" />
-		<f:form.hidden name="redirect" value="{f:uri.action(action: 'index', arguments: {lastEdited: id, id: returnId})}" />
+		<f:form.hidden name="returnUrl" value="{returnUrl}" />
 
 	</f:form>
 

--- a/Resources/Private/Templates/Permission/Index.html
+++ b/Resources/Private/Templates/Permission/Index.html
@@ -82,7 +82,7 @@
 								<td align="left" nowrap="nowrap">
 									<f:link.action
 										action="edit"
-										arguments="{id: '{f:if(condition: data.row._ORIG_uid, then: data.row._ORIG_uid, else: data.row.uid)}', depth: depth}"
+										arguments="{id: '{f:if(condition: data.row._ORIG_uid, then: data.row._ORIG_uid, else: data.row.uid)}', depth: depth, returnUrl: '{f:uri.action(action: \'index\', arguments: {id: currentId, depth: depth})}'}"
 										title="{f:translate(key: 'LLL:EXT:beuser/Resources/Private/Language/locallang_mod_permission.xlf:ch_permissions')}"
 									>
 										<f:format.raw>{data.depthData}{data.HTML}</f:format.raw>
@@ -96,7 +96,7 @@
 									</f:comment>
 									<f:link.action
 										action="edit"
-										arguments="{id: '{f:if(condition: data.row._ORIG_uid, then: data.row._ORIG_uid, else: data.row.uid)}', depth: depth}"
+										arguments="{id: '{f:if(condition: data.row._ORIG_uid, then: data.row._ORIG_uid, else: data.row.uid)}', depth: depth, returnUrl: '{f:uri.action(action: \'index\', arguments: {id: currentId, depth: depth})}'}"
 										class="btn btn-default"
 										title="{f:translate(key: 'LLL:EXT:beuser/Resources/Private/Language/locallang_mod_permission.xlf:ch_permissions')}"
 									>


### PR DESCRIPTION
Current TYPO3 TER version and master open the complete backend in the module frame. These two little changes solve the issue, so only the index view is shown after saving the data.

