### PR TITLE
BUGFIX: Set returnUrl if empty

### DIFF
--- a/Classes/Controller/PermissionController.php
+++ b/Classes/Controller/PermissionController.php
@@ -60,6 +60,23 @@ class PermissionController extends \TYPO3\CMS\Beuser\Controller\PermissionContro
      *****************************/
 
     /**
+     * Initialize action
+     *
+     * @return void
+     */
+    protected function initializeAction()
+    {
+        parent::initializeAction();
+
+        if(empty($this->returnUrl)) {
+            $this->returnUrl = $this->uriBuilder->reset()->setArguments([
+                'action' => 'index',
+                'id' => $this->id
+                ])->buildBackendUri();
+        }
+    }
+
+    /**
      * Initializes view
      *
      * @param ViewInterface $view The view to be initialized


### PR DESCRIPTION
Editing an ACL in TYPO3 7.6.24 currently leads to an exception

  Button "TYPO3\CMS\Backend\Template\Components\Buttons\LinkButton" is not valid

in typo3/sysext/backend/Classes/Template/Components/ButtonBar.php in line 66. (The returnUrl is not set for the "Close" Button)