### PR TITLE
Support PHP 7.2

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -28,7 +28,7 @@ $EM_CONF[$_EXTKEY] = array(
 	'CGLcompliance_note' => '',
 	'constraints' => array(
 		'depends' => array(
-			'php' => '5.5.0-7.1.99',
+			'php' => '5.5.0-7.2.99',
 			'typo3' => '7.6.0-8.9.99',
 		),
 		'conflicts' => array(


### PR DESCRIPTION
As this extension works in PHP 7.2 environments on TYPO3 8.7, this PHP
version is allowed.