### PR TITLE
[BUGFIX] Provide fallback for overly long cache identifier

### DIFF
--- a/Classes/Cache/PermissionCache.php
+++ b/Classes/Cache/PermissionCache.php
@@ -215,6 +215,10 @@ class PermissionCache implements SingletonInterface
 		$usergroup_cached_list = str_replace( ',', '_', $this->backendUser->user['usergroup_cached_list'] );
         $identifier = static::CACHE_IDENTIFIER_PERMISSIONS . '_' . $this->backendUser->user['uid'] . '_' . $usergroup_cached_list . '_' . $this->backendUser->user['workspace_id'];
 
+        if (strlen($identifier) > 250) {
+            $identifier = $identifier = static::CACHE_IDENTIFIER_PERMISSIONS . '_' . $this->backendUser->user['uid'];
+        }
+
         $requestedPermissions = trim($requestedPermissions);
         if ($requestedPermissions !== '') {
             $identifier .= '_' . $requestedPermissions;


### PR DESCRIPTION
When there are many many BE user groups and a large hierarchy, the generated
cache identifier will become too long, as it is limited to 250 characters.

The solution is to provide a fallback to the behaviour before commit

Fixes: https://forge.typo3.org/issues/88206