### PR TITLE
Added enableRedis to ext_conf_template

### DIFF
--- a/Resources/Private/Partials/Permission/EditAclRow.html
+++ b/Resources/Private/Partials/Permission/EditAclRow.html
@@ -3,7 +3,7 @@
 <tr class="tx_beacl-edit-acl-row" data-acluid="{pageAcl.uid}">
 	<td>
 		<div class="row">
-			<div class="col-xs-12 col-sm-6">
+			<div class="col-xs-12 col-md-6">
 				<f:render
 					partial="Permission/EditTypeSelector"
 					arguments="{
@@ -13,7 +13,7 @@
 					}"
 				/>
 			</div>
-			<div class="col-xs-12 col-sm-6">
+			<div class="col-xs-12 col-md-6">
 				<f:if condition="{pageAcl.type}==1">
 					<f:then>
 						<f:render

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -3,3 +3,6 @@ disableOldPermissionSystem = 0
 
 # cat=basic/enable; type=boolean; label=enable selector for users/groups - VERY useful if there are many ACLs
 enableFilterSelector = 1
+
+# cat=basic/enable; type=boolean; label=enable redis cache
+enableRedis = 0

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,6 +3,8 @@ if (!defined('TYPO3_MODE')) {
 	die ('Access denied.');
 }
 
+$_EXTCONF = $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['be_acl'];
+
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addUserTSConfig('
 	options.saveDocNew.tx_beacl_acl=1
 ');
@@ -19,7 +21,7 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['proc
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass'][] = 'JBartels\\BeAcl\\Hook\\DataHandlerHook';
 
 
-$redisLoaded = extension_loaded('redis');
+$redisLoaded = extension_loaded('redis') && $_EXTCONF['enableRedis'];
 
 // set tx_be_acl_timestamp-cache
 if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['tx_be_acl_timestamp']['frontend'])) {


### PR DESCRIPTION
Description of the problem :
In ddev environment we have error during cache flushing
`Call to a member function alert() on null | Error thrown in file /var/www/html/public/typo3/sysext/core/Classes/Cache/Backend/RedisBackend.php in line 163`

It is not enough to check only `extension_loaded('redis')` because In ddev environment redis loaded anyway, but may be not configured. So added new config enableRedis to ext_conf_template 

And other small fixes :
1. fixed EditAclRow.html template for responsive view